### PR TITLE
Fix vulnerability

### DIFF
--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -4,6 +4,7 @@ class BlogsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index show]
 
   before_action :set_blog, only: %i[show edit update destroy]
+  before_action :authorize_owner, only: %i[edit update destroy]
 
   def index
     @blogs = Blog.search(params[:term]).published.default_order
@@ -44,10 +45,14 @@ class BlogsController < ApplicationController
   private
 
   def set_blog
-    @blog = Blog.find(params[:id])
+    @blog = action_name == 'show' ? Blog.find(params[:id]) : current_user.blogs.find(params[:id])
   end
 
   def blog_params
     params.require(:blog).permit(:title, :content, :secret, :random_eyecatch)
+  end
+
+  def authorize_owner
+    redirect_to blogs_url, alert: 'You are not the owner of this blog.' unless @blog.owned_by?(current_user)
   end
 end

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -45,7 +45,15 @@ class BlogsController < ApplicationController
   private
 
   def set_blog
-    @blog = action_name == 'show' ? Blog.find(params[:id]) : current_user.blogs.find(params[:id])
+    action_name == 'show' ? set_visible_blog : set_owned_blog
+  end
+
+  def set_visible_blog
+    @blog = Blog.find_by(id: params[:id], secret: false) || Blog.find_by!(id: params[:id], user: current_user)
+  end
+
+  def set_owned_blog
+    @blog = current_user.blogs.find(params[:id])
   end
 
   def blog_params

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -29,6 +29,8 @@ class BlogsController < ApplicationController
   end
 
   def update
+    return redirect_to blogs_url, alert: 'This request is invalid.' if blog_params[:random_eyecatch] && !current_user.premium
+
     if @blog.update(blog_params)
       redirect_to blog_url(@blog), notice: 'Blog was successfully updated.'
     else

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -3,7 +3,6 @@
 class BlogsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index show]
 
-  before_action :set_visible_blog, only: %i[show]
   before_action :set_owned_blog, only: %i[edit update destroy]
   before_action :authorize_owner, only: %i[edit update destroy]
 
@@ -11,7 +10,9 @@ class BlogsController < ApplicationController
     @blogs = Blog.search(params[:term]).published.default_order
   end
 
-  def show; end
+  def show
+    @blog = Blog.visible_to(current_user).find(params[:id])
+  end
 
   def new
     @blog = Blog.new
@@ -44,10 +45,6 @@ class BlogsController < ApplicationController
   end
 
   private
-
-  def set_visible_blog
-    @blog = Blog.where(id: params[:id], secret: false).or(Blog.where(id: params[:id], user_id: current_user&.id)).first!
-  end
 
   def set_owned_blog
     @blog = current_user.blogs.find(params[:id])

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -3,7 +3,8 @@
 class BlogsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index show]
 
-  before_action :set_blog, only: %i[show edit update destroy]
+  before_action :set_visible_blog, only: %i[show]
+  before_action :set_owned_blog, only: %i[edit update destroy]
   before_action :authorize_owner, only: %i[edit update destroy]
 
   def index
@@ -46,12 +47,8 @@ class BlogsController < ApplicationController
 
   private
 
-  def set_blog
-    action_name == 'show' ? set_visible_blog : set_owned_blog
-  end
-
   def set_visible_blog
-    @blog = Blog.find_by(id: params[:id], secret: false) || Blog.find_by!(id: params[:id], user: current_user)
+    @blog = Blog.where(id: params[:id], secret: false).or(Blog.where(id: params[:id], user_id: current_user&.id)).first!
   end
 
   def set_owned_blog

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -4,7 +4,6 @@ class BlogsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index show]
 
   before_action :set_owned_blog, only: %i[edit update destroy]
-  before_action :authorize_owner, only: %i[edit update destroy]
 
   def index
     @blogs = Blog.search(params[:term]).published.default_order
@@ -55,9 +54,5 @@ class BlogsController < ApplicationController
     base_params << :random_eyecatch if current_user.premium
 
     params.require(:blog).permit(*base_params)
-  end
-
-  def authorize_owner
-    redirect_to blogs_url, alert: 'You are not the owner of this blog.' unless @blog.owned_by?(current_user)
   end
 end

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -30,8 +30,6 @@ class BlogsController < ApplicationController
   end
 
   def update
-    return redirect_to blogs_url, alert: 'This request is invalid.' if blog_params[:random_eyecatch] && !current_user.premium
-
     if @blog.update(blog_params)
       redirect_to blog_url(@blog), notice: 'Blog was successfully updated.'
     else
@@ -56,7 +54,10 @@ class BlogsController < ApplicationController
   end
 
   def blog_params
-    params.require(:blog).permit(:title, :content, :secret, :random_eyecatch)
+    base_params = %i[title content secret]
+    base_params << :random_eyecatch if current_user.premium
+
+    params.require(:blog).permit(*base_params)
   end
 
   def authorize_owner

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -50,9 +50,9 @@ class BlogsController < ApplicationController
   end
 
   def blog_params
-    base_params = %i[title content secret]
-    base_params << :random_eyecatch if current_user.premium
+    params_keys = %i[title content secret]
+    params_keys << :random_eyecatch if current_user.premium
 
-    params.require(:blog).permit(*base_params)
+    params.require(:blog).permit(*params_keys)
   end
 end

--- a/app/helpers/blogs_helper.rb
+++ b/app/helpers/blogs_helper.rb
@@ -2,6 +2,6 @@
 
 module BlogsHelper
   def format_content(blog)
-    blog.content.gsub("\n", '<br>').html_safe # rubocop:disable Rails/OutputSafety
+    h(blog.content).gsub(/\n|\r|\r\n/, '<br>').html_safe # rubocop:disable Rails/OutputSafety
   end
 end

--- a/app/helpers/blogs_helper.rb
+++ b/app/helpers/blogs_helper.rb
@@ -2,6 +2,6 @@
 
 module BlogsHelper
   def format_content(blog)
-    h(blog.content).gsub(/\n|\r|\r\n/, '<br>').html_safe # rubocop:disable Rails/OutputSafety
+    safe_join(blog.content.split("\n"), tag.br)
   end
 end

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -10,7 +10,7 @@ class Blog < ApplicationRecord
   scope :published, -> { where('secret = FALSE') }
 
   scope :search, lambda { |term|
-    where("title LIKE '%#{term}%' OR content LIKE '%#{term}%'")
+    where('title LIKE ? OR content LIKE ?', "%#{term}%", "%#{term}%")
   }
 
   scope :default_order, -> { order(id: :desc) }

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -16,7 +16,7 @@ class Blog < ApplicationRecord
   scope :default_order, -> { order(id: :desc) }
 
   scope :visible_to, lambda { |user|
-    where(secret: false).or(where(user_id: user&.id))
+    published.or(where(user:))
   }
 
   def owned_by?(target_user)

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -15,6 +15,10 @@ class Blog < ApplicationRecord
 
   scope :default_order, -> { order(id: :desc) }
 
+  scope :visible_to, lambda { |user|
+    where(secret: false).or(where(user_id: user&.id))
+  }
+
   def owned_by?(target_user)
     user == target_user
   end

--- a/app/views/api/liking_users/_user.json.jbuilder
+++ b/app/views/api/liking_users/_user.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! user, :id, :email, :created_at, :updated_at, :nickname, :premium
+json.extract! user, :id, :created_at, :updated_at, :nickname, :premium

--- a/app/views/api/liking_users/_user.json.jbuilder
+++ b/app/views/api/liking_users/_user.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! user, :id, :created_at, :updated_at, :nickname, :premium
+json.extract! user, :id, :nickname

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
 
   def sign_in_as(user)
     visit root_path


### PR DESCRIPTION
## 申し送り
初期パスワードとして`password`が設定されていますが、Google Chromeを使っている場合、`データ侵害によりパスワードが漏洩した場合に警告する`という設定がenabledになっていると、テストの動作が不安定になるという問題が確認できました。
`データ侵害によりパスワードが漏洩した場合に警告する`はデフォルトの設定であり、また外すべきではないという認識であるため、初期パスワードを変更した状態でPR作成しています。

同様の理由で、`:headless_chrome`によるテストは動作が不安定になるため`:chrome`に変更した状態でPR作成しています。

---

`bin/rails test:all`, `rubocop -A`の実行結果
<img width="730" alt="スクリーンショット 2025-05-01 13 53 41" src="https://github.com/user-attachments/assets/437955a5-fbd7-4646-9fce-07b054abc7a3" />

```
$ rubocop -A
Inspecting 26 files
..........................

26 files inspected, no offenses detected
```

```
$ bin/rails test:all

up to date, audited 21 packages in 312ms

1 package is looking for funding
  run `npm fund` for details

found 0 vulnerabilities

> build
> esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=assets


  app/assets/builds/application.js      1.2mb ⚠️
  app/assets/builds/application.js.map  2.0mb

⚡ Done in 29ms
Running 16 tests in a single process (parallelization threshold is 50)
Run options: --seed 34346

# Running:

.......Capybara starting Puma...
* Version 6.3.0 , codename: Mugi No Toki Itaru
* Min threads: 0, max threads: 4
* Listening on http://127.0.0.1:58819
.........

Finished in 5.846548s, 2.7367 runs/s, 11.9729 assertions/s.
16 runs, 70 assertions, 0 failures, 0 errors, 0 skips
```